### PR TITLE
Docker image building in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Exclude everything from the Docker build context except the pre-built tgz.
+# The tgz is produced by the CI build-and-test job and downloaded
+# before docker/build-push-action runs.
+*
+!G4beamline-*.tgz

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,14 @@
-# Exclude everything from the Docker build context except the pre-built tgz.
-# The tgz is produced by the CI build-and-test job and downloaded
-# before docker/build-push-action runs.
-*
-!G4beamline-*.tgz
+# Build artifacts
+build/
+*.o
+*.a
+
+# Version control
+.git/
+
+# CI-generated files
+Dockerfile.ci
+
+# Editor / OS noise
+.DS_Store
+*.swp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           context: .
           push: false
           build-args: BUILD_COMMIT=${{ github.sha }}
+          cache-from: type=gha
           cache-to: type=gha,mode=max
 
   docker-build-push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           context: .
           push: false
+          build-args: BUILD_COMMIT=${{ github.sha }}
           cache-to: type=gha,mode=max
 
   docker-build-push:
@@ -71,5 +72,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
           ls -la
           test -x bin/g4bl
 
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: g4beamline-ubuntu22
+          path: build/G4beamline-3.08-Ubuntu22.tgz
+          if-no-files-found: error
+
   docker-build-push:
     needs: build-and-test
     runs-on: ubuntu-latest
@@ -64,6 +71,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Download pre-built distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: g4beamline-ubuntu22
+          path: .
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -100,8 +113,8 @@ jobs:
 
       - name: Verify Docker image
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}:sha-$(echo '${{ github.sha }}' | cut -c1-7)"
-          docker pull "${IMAGE}"
-          docker run --rm "${IMAGE}" test -x /g4beamline/bin/g4bl
+          TAG="ghcr.io/${{ github.repository }}:sha-$(echo "${{ github.sha }}" | cut -c1-7)"
+          docker pull "${TAG}"
+          docker run --rm "${TAG}" ls -la /g4beamline/
+          docker run --rm "${TAG}" test -x /g4beamline/bin/g4bl
           echo "Verified: /g4beamline/bin/g4bl exists and is executable"
-          docker run --rm "${IMAGE}" ls -la /g4beamline/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           context: .
           push: true
+          no-cache: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,10 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
-        env:
-          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: false
-          cache-from: type=gha
+          progress: plain
           cache-to: type=gha,mode=max
 
   docker-build-push:
@@ -65,11 +63,10 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
-        env:
-          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: true
+          progress: plain
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: false
@@ -63,6 +65,8 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,44 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    container:
+      image: artemisbeta/geant4:11.0.2
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install dependencies
+        run: |
+          apt-get install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+          apt-get install -y libgsl-dev
+          apt-get install -y fftw3-dev wget
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        env:
-          BUILDKIT_PROGRESS: plain
-        with:
-          context: .
-          push: false
-          build-args: BUILD_COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          echo "GSL_DIR=/usr" >> $GITHUB_ENV
+          echo "FFTW_DIR=/usr" >> $GITHUB_ENV
+
+          wget --no-verbose https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+          tar xf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz -C /opt
+          rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+          test -d /opt/root/bin
+
+          echo "ROOTSYS=/opt/root" >> $GITHUB_ENV
+          echo "ROOT_DIR=/opt/root" >> $GITHUB_ENV
+          echo "Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/" >> $GITHUB_ENV
+
+      - name: Build project
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DROOT_DIR=/opt/root
+          cmake --build . --config Release --target install
+
+      - name: Verify build output
+        run: |
+          cd build
+          pwd
+          ls -la
+          test -x bin/g4bl
 
   docker-build-push:
     needs: build-and-test
@@ -73,6 +94,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: BUILD_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: false
-          progress: plain
           cache-to: type=gha,mode=max
 
   docker-build-push:
@@ -63,10 +64,11 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: true
-          progress: plain
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
           name: g4beamline-ubuntu22
           path: .
 
+      - name: Inspect downloaded artifact
+        run: |
+          echo "=== Files in working directory ==="
+          ls -la .
+          echo "=== Archive size ==="
+          du -sh G4beamline-*.tgz
+          echo "=== Archive top-level structure (first 30 entries) ==="
+          tar -tzf G4beamline-*.tgz | head -30
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -114,6 +123,11 @@ jobs:
         run: |
           TAG="ghcr.io/${{ github.repository }}:sha-$(echo "${{ github.sha }}" | cut -c1-7)"
           docker pull "${TAG}"
+          echo "=== Top-level /g4beamline contents ==="
           docker run --rm "${TAG}" ls -la /g4beamline/
+          echo "=== Find g4bl anywhere in image ==="
+          docker run --rm "${TAG}" find / -name g4bl 2>/dev/null || true
+          echo "=== Full /g4beamline tree (depth 3) ==="
+          docker run --rm "${TAG}" find /g4beamline -maxdepth 3 -ls 2>/dev/null | head -30
           docker run --rm "${TAG}" test -x /g4beamline/bin/g4bl
           echo "Verified: /g4beamline/bin/g4bl exists and is executable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,55 +12,20 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    container:
-      image: artemisbeta/geant4:11.0.2
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies (if needed)
-        run: |
-          #conda install -y cmake make gxx # Add other dependencies here
-          #conda clean -a
-          # apt-get update
-          apt-get install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
-          apt-get install -y libgsl-dev
-          export GSL_DIR=/usr
-          apt-get install -y fftw3-dev
-          export FFTW_DIR=/usr
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          echo "GSL_DIR=$GSL_DIR" >> $GITHUB_ENV
-          echo "FFTW_DIR=$FFTW_DIR" >> $GITHUB_ENV
-
-
-          wget https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
-          tar xvf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
-          export ROOTSYS=$PWD/root/
-          export ROOT_DIR=$PWD/root/
-
-          echo "ROOTSYS=$ROOTSYS" >> $GITHUB_ENV
-          echo "ROOT_DIR=$ROOT_DIR" >> $GITHUB_ENV
-          
-          export Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
-          echo "Geant4_DIR=$Geant4_DIR" >> $GITHUB_ENV
-          
-
-
-
-      - name: Build project
-        run: |
-          mkdir -p build
-          cd build
-          cmake ..
-          cmake --build . --config Release --target install
-
-      - name: Run tests
-        run: |
-          cd build
-          pwd; ls
-          #ctest --output-on-failure
-          # or replace with ./run_tests.sh or pytest
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   docker-build-push:
     needs: build-and-test
@@ -75,6 +40,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -100,3 +68,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
+      - name: Verify Docker image
+        run: |
+          TAG="ghcr.io/${{ github.repository }}:sha-$(echo "${{ github.sha }}" | cut -c1-7)"
+          docker pull "${TAG}"
+          docker run --rm "${TAG}" ls -la /g4beamline/
+          docker run --rm "${TAG}" test -x /g4beamline/bin/g4bl
+          echo "Verified: /g4beamline/bin/g4bl exists and is executable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     # Run on pull request to any branch
     branches: ['**']
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -19,73 +23,84 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install dependencies (if needed)
         run: |
+          #conda install -y cmake make gxx # Add other dependencies here
+          #conda clean -a
+          # apt-get update
           apt-get install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
           apt-get install -y libgsl-dev
-          apt-get install -y fftw3-dev wget
+          export GSL_DIR=/usr
+          apt-get install -y fftw3-dev
+          export FFTW_DIR=/usr
 
-          echo "GSL_DIR=/usr" >> $GITHUB_ENV
-          echo "FFTW_DIR=/usr" >> $GITHUB_ENV
+          echo "GSL_DIR=$GSL_DIR" >> $GITHUB_ENV
+          echo "FFTW_DIR=$FFTW_DIR" >> $GITHUB_ENV
 
-          wget --no-verbose https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
-          tar xf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz -C /opt
-          rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
-          test -d /opt/root/bin
 
-          echo "ROOTSYS=/opt/root" >> $GITHUB_ENV
-          echo "ROOT_DIR=/opt/root" >> $GITHUB_ENV
-          echo "Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/" >> $GITHUB_ENV
+          wget https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+          tar xvf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+          export ROOTSYS=$PWD/root/
+          export ROOT_DIR=$PWD/root/
+
+          echo "ROOTSYS=$ROOTSYS" >> $GITHUB_ENV
+          echo "ROOT_DIR=$ROOT_DIR" >> $GITHUB_ENV
+          
+          export Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
+          echo "Geant4_DIR=$Geant4_DIR" >> $GITHUB_ENV
+          
+
+
 
       - name: Build project
         run: |
           mkdir -p build
           cd build
-          cmake .. -DROOT_DIR=/opt/root
+          cmake ..
           cmake --build . --config Release --target install
 
-      - name: Verify build output
+      - name: Smoke test g4bl runtime
         run: |
           cd build
-          pwd
-          ls -la
-          test -x bin/g4bl
+          ldd ./bin/g4bl | tee /tmp/ldd-g4bl.txt
+          if grep -q "not found" /tmp/ldd-g4bl.txt; then
+            echo "Missing shared libraries for g4bl"
+            exit 1
+          fi
 
-      - name: Upload distribution artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: g4beamline-ubuntu22
-          path: build/G4beamline-3.08-Ubuntu22.tgz
-          if-no-files-found: error
+          status=0
+          timeout 10s ./bin/g4bl --help >/tmp/g4bl-smoke.log 2>&1 || status=$?
+          if [ "$status" -eq 124 ]; then
+            echo "g4bl --help timed out after 10s; treating as pass because process started"
+            status=0
+          fi
 
-  docker-build-push:
+          tail -n 50 /tmp/g4bl-smoke.log
+
+          if grep -q "error while loading shared libraries" /tmp/g4bl-smoke.log; then
+            echo "g4bl failed to start due to linker/runtime library error"
+            exit 1
+          fi
+          if [ "$status" -eq 127 ]; then
+            echo "g4bl failed to execute"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: |
+          cd build
+          pwd; ls
+          #ctest --output-on-failure
+          # or replace with ./run_tests.sh or pytest
+
+  build-and-push-container:
     needs: build-and-test
-    runs-on: ubuntu-latest
-    # Only push images on pushes (not on pull requests) to avoid exposing secrets
     if: github.event_name == 'push'
-
-    permissions:
-      contents: read
-      packages: write
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Download pre-built distribution artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: g4beamline-ubuntu22
-          path: .
-
-      - name: Inspect downloaded artifact
-        run: |
-          echo "=== Files in working directory ==="
-          ls -la .
-          echo "=== Archive size ==="
-          du -sh G4beamline-*.tgz
-          echo "=== Archive top-level structure (first 30 entries) ==="
-          tar -tzf G4beamline-*.tgz | head -30
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -101,33 +116,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/g4beamline
           tags: |
+            type=sha
             type=ref,event=branch
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
-      - name: Build and push Docker image
-        id: push
+      - name: Build and push image
         uses: docker/build-push-action@v6
-        env:
-          BUILDKIT_PROGRESS: plain
         with:
           context: .
+          file: Dockerfile
           push: true
-          no-cache: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Verify Docker image
-        run: |
-          TAG="ghcr.io/${{ github.repository }}:sha-$(echo "${{ github.sha }}" | cut -c1-7)"
-          docker pull "${TAG}"
-          echo "=== Top-level /g4beamline contents ==="
-          docker run --rm "${TAG}" ls -la /g4beamline/
-          echo "=== Find g4bl anywhere in image ==="
-          docker run --rm "${TAG}" find / -name g4bl 2>/dev/null || true
-          echo "=== Full /g4beamline tree (depth 3) ==="
-          docker run --rm "${TAG}" find /g4beamline -maxdepth 3 -ls 2>/dev/null | head -30
-          docker run --rm "${TAG}" test -x /g4beamline/bin/g4bl
-          echo "Verified: /g4beamline/bin/g4bl exists and is executable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v6
         env:
           BUILDKIT_PROGRESS: plain
@@ -96,3 +97,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify Docker image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}:sha-$(echo '${{ github.sha }}' | cut -c1-7)"
+          docker pull "${IMAGE}"
+          docker run --rm "${IMAGE}" test -x /g4beamline/bin/g4bl
+          echo "Verified: /g4beamline/bin/g4bl exists and is executable"
+          docker run --rm "${IMAGE}" ls -la /g4beamline/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,42 @@ jobs:
           pwd; ls
           #ctest --output-on-failure
           # or replace with ./run_tests.sh or pytest
+
+  docker-build-push:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # Only push images on pushes (not on pull requests) to avoid exposing secrets
+    if: github.event_name == 'push'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Verify Docker image
-        run: |
-          TAG="ghcr.io/${{ github.repository }}:sha-$(echo "${{ github.sha }}" | cut -c1-7)"
-          docker pull "${TAG}"
-          docker run --rm "${TAG}" ls -la /g4beamline/
-          docker run --rm "${TAG}" test -x /g4beamline/bin/g4bl
-          echo "Verified: /g4beamline/bin/g4bl exists and is executable"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,18 @@ ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 # Copy source code
 COPY . /g4beamline
 
+# Cache-bust argument: changing this (or passing a unique value via --build-arg)
+# forces cmake to re-run even when earlier layers are cached by content hash.
+# In CI this is set to github.sha so every commit gets a fresh build.
+ARG BUILD_COMMIT=unknown
+
 # Build and install
 RUN mkdir -p /g4beamline/build && \
     cd /g4beamline/build && \
     cmake .. -DROOT_DIR=/opt/root && \
     cmake --build . --config Release --target install
+
+# Verify the build produced the expected binary
+RUN test -x /g4beamline/build/bin/g4bl
 
 WORKDIR /g4beamline/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,27 @@
 FROM artemisbeta/geant4:11.0.2
 
-# Install system dependencies
+# Install runtime system dependencies needed by g4blgui
 RUN apt-get update && apt-get install -y \
     qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
     libgsl-dev \
     fftw3-dev \
-    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Set GSL and FFTW dirs
 ENV GSL_DIR=/usr
 ENV FFTW_DIR=/usr
 
-# Install ROOT
-RUN wget --no-verbose https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
-    && tar xf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz -C /opt \
-    && rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
-    && test -d /opt/root/bin
-
-ENV ROOTSYS=/opt/root
-ENV ROOT_DIR=/opt/root
-ENV PATH="${ROOTSYS}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${LD_LIBRARY_PATH}"
-
 # Set Geant4 directory
 ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 
-# Copy source into /src
-WORKDIR /src
-COPY . .
-
-# Build directly in /g4beamline.
-# CMakeLists.txt requires CMAKE_INSTALL_PREFIX == CMAKE_BINARY_DIR,
-# so building in /g4beamline means the binaries and installed files all
-# land there without any additional copy step.
-RUN mkdir -p /g4beamline && cd /g4beamline \
-    && cmake /src -DROOT_DIR=/opt/root \
-    && cmake --build . --config Release --target install \
+# Extract the pre-built G4beamline distribution produced by CI.
+# The tgz is downloaded from the GitHub Actions artifact store before
+# docker/build-push-action runs; the .dockerignore ensures it is the
+# only file sent in the build context.
+RUN mkdir -p /g4beamline
+COPY G4beamline-*.tgz /tmp/
+RUN tar -xf /tmp/G4beamline-*.tgz --strip-components=1 -C /g4beamline \
+    && rm /tmp/G4beamline-*.tgz \
     && test -x /g4beamline/bin/g4bl
 
 WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,16 @@ ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${LD_LIBRARY_PATH}"
 # Set Geant4 directory
 ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 
-# Copy source and build
+# Copy source into /src
 WORKDIR /src
 COPY . .
 
-RUN mkdir -p build && cd build \
-    && cmake .. -DROOT_DIR=/opt/root \
+# Build directly in /g4beamline.
+# CMakeLists.txt requires CMAKE_INSTALL_PREFIX == CMAKE_BINARY_DIR,
+# so building in /g4beamline means the binaries and installed files all
+# land there without any additional copy step.
+RUN mkdir -p /g4beamline && cd /g4beamline \
+    && cmake /src -DROOT_DIR=/opt/root \
     && cmake --build . --config Release --target install
-
-# Copy installed files into /g4beamline
-RUN cp -a /src/build/. /g4beamline/
 
 WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,10 @@ RUN set -eux; \
 # can load them under kernels older than the tag's minimum (3.17).
 RUN for f in /lib/x86_64-linux-gnu/libQt5*.so*; do \
         [ -L "$f" ] && continue; \
-        readelf -n "$f" 2>/dev/null | grep -q "ABI: 3.17" && \
-            echo "Stripping ABI tag from $f" && \
+        if readelf -n "$f" 2>/dev/null | grep -q "ABI: 3.17"; then \
+            echo "Stripping ABI tag from $f"; \
             strip --remove-section=.note.ABI-tag "$f"; \
+        fi; \
     done
 
 ENV GSL_DIR=/usr

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ ENV GSL_DIR=/usr
 ENV FFTW_DIR=/usr
 
 # Install ROOT
-RUN wget -q https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
+RUN wget --no-verbose https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
     && tar xf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz -C /opt \
-    && rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+    && rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
+    && test -d /opt/root/bin
 
 ENV ROOTSYS=/opt/root
 ENV ROOT_DIR=/opt/root
@@ -31,7 +32,7 @@ COPY . /g4beamline
 # Build and install
 RUN mkdir -p /g4beamline/build && \
     cd /g4beamline/build && \
-    cmake .. && \
+    cmake .. -DROOT_DIR=/opt/root && \
     cmake --build . --config Release --target install
 
 WORKDIR /g4beamline/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,22 +26,4 @@ ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${LD_LIBRARY_PATH}"
 # Set Geant4 directory
 ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 
-# Copy source code
-COPY . /g4beamline
-
-# Cache-bust argument: changing this (or passing a unique value via --build-arg)
-# forces cmake to re-run even when earlier layers are cached by content hash.
-# In CI this is set to github.sha so every commit gets a fresh build.
-ARG BUILD_COMMIT=unknown
-
-# Build and install
-RUN echo "Building commit: ${BUILD_COMMIT}" && \
-    mkdir -p /g4beamline/build && \
-    cd /g4beamline/build && \
-    cmake .. -DROOT_DIR=/opt/root && \
-    cmake --build . --config Release --target install
-
-# Verify the build produced the expected binary
-RUN test -x /g4beamline/build/bin/g4bl
-
-WORKDIR /g4beamline/build
+WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,15 @@ ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${LD_LIBRARY_PATH}"
 # Set Geant4 directory
 ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 
+# Copy source and build
+WORKDIR /src
+COPY . .
+
+RUN mkdir -p build && cd build \
+    && cmake .. -DROOT_DIR=/opt/root \
+    && cmake --build . --config Release --target install
+
+# Copy installed files into /g4beamline
+RUN cp -a /src/build/. /g4beamline/
+
 WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY . .
 # land there without any additional copy step.
 RUN mkdir -p /g4beamline && cd /g4beamline \
     && cmake /src -DROOT_DIR=/opt/root \
-    && cmake --build . --config Release --target install
+    && cmake --build . --config Release --target install \
+    && test -x /g4beamline/bin/g4bl
 
 WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,16 @@ ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
 # only file sent in the build context.
 RUN mkdir -p /g4beamline
 COPY G4beamline-*.tgz /tmp/
-RUN tar -xf /tmp/G4beamline-*.tgz --strip-components=1 -C /g4beamline \
+RUN echo "=== Archive in /tmp ===" \
+    && ls -lh /tmp/G4beamline-*.tgz \
+    && echo "=== First 30 entries in archive ===" \
+    && tar -tzf /tmp/G4beamline-*.tgz | head -30 \
+    && echo "=== Extracting ===" \
+    && tar -xvf /tmp/G4beamline-*.tgz --strip-components=1 -C /g4beamline 2>&1 | head -30 \
+    && echo "=== /g4beamline contents after extraction ===" \
+    && ls -la /g4beamline/ \
     && rm /tmp/G4beamline-*.tgz \
-    && test -x /g4beamline/bin/g4bl
+    && test -x /g4beamline/bin/g4bl \
+    && echo "SUCCESS: g4bl is executable"
 
 WORKDIR /g4beamline

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,17 @@ RUN apt-get update && apt-get install -y \
     qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
     libgsl-dev \
     fftw3-dev \
+    binutils \
     && rm -rf /var/lib/apt/lists/*
+
+# Strip the ABI version tag from Qt5 shared libraries so the dynamic linker
+# can load them under kernels older than the tag's minimum (3.17).
+RUN for f in /lib/x86_64-linux-gnu/libQt5*.so*; do \
+        [ -L "$f" ] && continue; \
+        readelf -n "$f" 2>/dev/null | grep -q "ABI: 3.17" && \
+            echo "Stripping ABI tag from $f" && \
+            strip --remove-section=.note.ABI-tag "$f"; \
+    done
 
 # Set GSL and FFTW dirs
 ENV GSL_DIR=/usr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM artemisbeta/geant4:11.0.2
+ARG GEANT4_VERSION=11.0.2
+FROM artemisbeta/geant4:${GEANT4_VERSION}
+ARG GEANT4_VERSION
+ARG ROOT_TARBALL=root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
 
-# Install runtime system dependencies needed by g4blgui
-RUN apt-get update && apt-get install -y \
-    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
-    libgsl-dev \
-    fftw3-dev \
-    binutils \
-    && rm -rf /var/lib/apt/lists/*
+SHELL ["/bin/bash", "-lc"]
+
+WORKDIR /opt/g4beamline
+
+# Install build-time and runtime dependencies
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libqt5core5a libqt5gui5 libqt5widgets5 \
+        qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+        libgsl-dev fftw3-dev; \
+    arch="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"; \
+    printf "/lib/%s\n/usr/lib/%s\n" "${arch}" "${arch}" > /etc/ld.so.conf.d/g4beamline-multiarch-libs.conf; \
+    ldconfig; \
+    ldconfig -p | grep -q "libQt5Core.so.5"; \
+    rm -rf /var/lib/apt/lists/*
 
 # Strip the ABI version tag from Qt5 shared libraries so the dynamic linker
 # can load them under kernels older than the tag's minimum (3.17).
@@ -17,29 +29,54 @@ RUN for f in /lib/x86_64-linux-gnu/libQt5*.so*; do \
             strip --remove-section=.note.ABI-tag "$f"; \
     done
 
-# Set GSL and FFTW dirs
 ENV GSL_DIR=/usr
 ENV FFTW_DIR=/usr
 
-# Set Geant4 directory
-ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
+# artemisbeta/geant4 uses install path /usr/local/share/geant4/install/4.<version>
+# with shared libraries under .../lib.
+ENV GEANT4_DIR=/usr/local/share/geant4/install/4.${GEANT4_VERSION}
+ENV GEANT4_LIB_DIR="${GEANT4_DIR}/lib"
 
-# Extract the pre-built G4beamline distribution produced by CI.
-# The tgz is downloaded from the GitHub Actions artifact store before
-# docker/build-push-action runs; the .dockerignore ensures it is the
-# only file sent in the build context.
-RUN mkdir -p /g4beamline
-COPY G4beamline-*.tgz /tmp/
-RUN echo "=== Archive in /tmp ===" \
-    && ls -lh /tmp/G4beamline-*.tgz \
-    && echo "=== First 30 entries in archive ===" \
-    && tar -tzf /tmp/G4beamline-*.tgz | head -30 \
-    && echo "=== Extracting ===" \
-    && tar -xvf /tmp/G4beamline-*.tgz --strip-components=1 -C /g4beamline 2>&1 | head -30 \
-    && echo "=== /g4beamline contents after extraction ===" \
-    && ls -la /g4beamline/ \
-    && rm /tmp/G4beamline-*.tgz \
-    && test -x /g4beamline/bin/g4bl \
-    && echo "SUCCESS: g4bl is executable"
+RUN set -eux; \
+    wget --tries=3 --waitretry=5 --timeout=60 \
+        -O /tmp/root.tar.gz \
+        https://root.cern/download/${ROOT_TARBALL}; \
+    tar xzf /tmp/root.tar.gz -C /opt/g4beamline; \
+    rm -f /tmp/root.tar.gz
 
-WORKDIR /g4beamline
+ENV ROOTSYS=/opt/g4beamline/root
+ENV ROOT_DIR=/opt/g4beamline/root
+ENV PATH="${ROOTSYS}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${GEANT4_LIB_DIR}:${LD_LIBRARY_PATH}"
+ENV PYTHONPATH="${ROOTSYS}/lib"
+RUN set -eux; command -v root; command -v root-config
+
+# Copy g4beamline source.
+# COPY does not remove pre-existing files (such as /opt/g4beamline/root),
+# so the ROOT tree is preserved.
+COPY . /opt/g4beamline
+
+# Build and install g4beamline.
+# IMPORTANT: CMakeLists.txt forces CMAKE_INSTALL_PREFIX == CMAKE_BINARY_DIR,
+# so "cmake --build . --target install" installs everything *into* the build
+# directory.  The programs must be run from there.  Do NOT remove the build
+# directory afterwards.  Only intermediate build artifacts are cleaned up to
+# keep the image size reasonable.
+RUN set -eux; \
+    mkdir -p /opt/g4beamline/build; \
+    cd /opt/g4beamline/build; \
+    cmake ..; \
+    cmake --build . --config Release --target install; \
+    ldd /opt/g4beamline/build/bin/g4bl | tee /tmp/ldd-g4bl.txt; \
+    if grep -q "not found" /tmp/ldd-g4bl.txt; then \
+        echo "Missing shared libraries for g4bl during image build"; \
+        exit 1; \
+    fi; \
+    find /opt/g4beamline/build -type f -name "*.o" -delete; \
+    find /opt/g4beamline/build -type d -name "CMakeFiles" -print0 | xargs -0r rm -rf
+
+# Add the build/install directory to PATH so all g4beamline executables
+# (g4bl, g4bltest, g4blgui, …) are on the default path.
+ENV PATH="/opt/g4beamline/build:${PATH}"
+
+WORKDIR /opt/g4beamline/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM artemisbeta/geant4:11.0.2
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    libgsl-dev \
+    fftw3-dev \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set GSL and FFTW dirs
+ENV GSL_DIR=/usr
+ENV FFTW_DIR=/usr
+
+# Install ROOT
+RUN wget -q https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz \
+    && tar xf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz -C /opt \
+    && rm root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+
+ENV ROOTSYS=/opt/root
+ENV ROOT_DIR=/opt/root
+ENV PATH="${ROOTSYS}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${ROOTSYS}/lib:${LD_LIBRARY_PATH}"
+
+# Set Geant4 directory
+ENV Geant4_DIR=/usr/local/share/geant4/install/4.11.0.2/lib/Geant4-11.0.2/
+
+# Copy source code
+COPY . /g4beamline
+
+# Build and install
+RUN mkdir -p /g4beamline/build && \
+    cd /g4beamline/build && \
+    cmake .. && \
+    cmake --build . --config Release --target install
+
+WORKDIR /g4beamline/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ COPY . /g4beamline
 ARG BUILD_COMMIT=unknown
 
 # Build and install
-RUN mkdir -p /g4beamline/build && \
+RUN echo "Building commit: ${BUILD_COMMIT}" && \
+    mkdir -p /g4beamline/build && \
     cd /g4beamline/build && \
     cmake .. -DROOT_DIR=/opt/root && \
     cmake --build . --config Release --target install


### PR DESCRIPTION
This PR adds a docker image building step to the CI, useful for developing g4bl. Uses the same base `artemisbeta/geant4:11.0.2` image used in the build test. Strange problem seen with finding libraries for Qt on host. Solved in cb2e6122019fab9bf505f6004abe9439eae340e3 with stripping ABI tags from libraries that were preventing older host kernels from running. Appears that I'm able to run the g4bl executable in this image now. 